### PR TITLE
dan: more meaningful error for invalid register/deregister response

### DIFF
--- a/iottalkpy/dan.py
+++ b/iottalkpy/dan.py
@@ -387,8 +387,7 @@ class Client:
             )
 
             if response.status_code != 200:
-                reason = response.json()['reason']
-                raise RegistrationError(reason)
+                raise RegistrationError(response.json()['reason'])
         except requests.exceptions.ConnectionError:
             raise RegistrationError('ConnectionError')
         except (KeyError, json.JSONDecodeError):
@@ -470,8 +469,7 @@ class Client:
             )
 
             if response.status_code != 200:
-                reason = response.json()['reason']
-                raise RegistrationError(reason)
+                raise RegistrationError(response.json()['reason'])
         except requests.exceptions.ConnectionError:
             raise RegistrationError('ConnectionError')
         except (KeyError, json.JSONDecodeError):

--- a/iottalkpy/dan.py
+++ b/iottalkpy/dan.py
@@ -387,8 +387,10 @@ class Client:
             )
 
             if response.status_code != 200:
-                raise RegistrationError(response.json()['reason'])
-        except requests.exceptions.ConnectionError:
+                reason = response.json()['reason']
+                raise RegistrationError(reason)
+        except (requests.exceptions.ConnectionError, KeyError,
+                json.JSONDecodeError) as e:
             raise RegistrationError('ConnectionError')
 
         metadata = response.json()
@@ -467,8 +469,10 @@ class Client:
             )
 
             if response.status_code != 200:
-                raise RegistrationError(response.json()['reason'])
-        except requests.exceptions.ConnectionError:
+                reason = response.json()['reason']
+                raise RegistrationError(reason)
+        except (requests.exceptions.ConnectionError, KeyError,
+                json.JSONDecodeError):
             raise RegistrationError('ConnectionError')
 
         self._disconn_lock.acquire()  # wait for disconnect finished

--- a/iottalkpy/dan.py
+++ b/iottalkpy/dan.py
@@ -389,9 +389,10 @@ class Client:
             if response.status_code != 200:
                 reason = response.json()['reason']
                 raise RegistrationError(reason)
-        except (requests.exceptions.ConnectionError, KeyError,
-                json.JSONDecodeError) as e:
+        except requests.exceptions.ConnectionError:
             raise RegistrationError('ConnectionError')
+        except (KeyError, json.JSONDecodeError):
+            raise RegistrationError('Invalid response from server')
 
         metadata = response.json()
         ctx.name = metadata['name']
@@ -471,9 +472,10 @@ class Client:
             if response.status_code != 200:
                 reason = response.json()['reason']
                 raise RegistrationError(reason)
-        except (requests.exceptions.ConnectionError, KeyError,
-                json.JSONDecodeError):
+        except requests.exceptions.ConnectionError:
             raise RegistrationError('ConnectionError')
+        except (KeyError, json.JSONDecodeError):
+            raise RegistrationError('Invalid response from server')
 
         self._disconn_lock.acquire()  # wait for disconnect finished
         del self._disconn_lock


### PR DESCRIPTION
close #16

example:
```python
Traceback (most recent call last):
  File "/data/usr/home/iblis/git/iottalk-py/iottalkpy/dan.py", line 390, in register
    reason = response.json()['reason']
  File "/data/usr/home/iblis/venv/iottalk-core/lib/python3.6/site-packages/requests/models.py", line 897, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/lib/python3.6/json/__init__.py", line 354, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.6/json/decoder.py", line 339, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.6/json/decoder.py", line 357, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/data/usr/home/iblis/git/iottalk-py/iottalkpy/dai.py", line 224, in <module>
    main(app)
  File "/data/usr/home/iblis/git/iottalk-py/iottalkpy/dai.py", line 201, in main
    on_disconnect=f
  File "/data/usr/home/iblis/git/iottalk-py/iottalkpy/dan.py", line 526, in register
    return _default_client.register(*args, **kwargs)
  File "/data/usr/home/iblis/git/iottalk-py/iottalkpy/dan.py", line 395, in register
    raise RegistrationError('Invalid response from server')
iottalkpy.dan.RegistrationError: Invalid response from server
```