### PR TITLE
fix: idf return type should be list, not tuple

### DIFF
--- a/iottalkpy/dan.py
+++ b/iottalkpy/dan.py
@@ -535,7 +535,7 @@ class Client:
         if ctx.i_chans.get(idf) is None:
             return False
 
-        data = data if isinstance(data, list) else [data]
+        data = data if isinstance(data, (list, tuple)) else [data]
         data = json.dumps(data)
 
         # TODO: make qos configurable


### PR DESCRIPTION
原本 IDF 若有多個 parameters 的話，只能使用 list 型別進行回傳，新增支援 tuple 型別回傳